### PR TITLE
feat: add logging middleware and monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,17 @@ services:
     command: npx hardhat node
     ports:
       - "8545:8545"
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - nuxt
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus

--- a/nuxt-app/package-lock.json
+++ b/nuxt-app/package-lock.json
@@ -18,6 +18,7 @@
         "vee-validate": "^4.12.6",
         "vue": "^3.5.18",
         "vue-router": "^4.5.1",
+        "winston": "^3.17.0",
         "zod": "^3.25.0"
       },
       "devDependencies": {

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -11,26 +11,27 @@
     "start": "nuxt start"
   },
   "dependencies": {
+    "@pinia/nuxt": "^0.4.11",
     "better-sqlite3": "^9.4.3",
+    "chart.js": "^4.4.1",
     "drizzle-orm": "^0.37.0",
     "ethers": "^6.11.1",
-    "nuxt": "^4.0.1",
-    "vue": "^3.5.18",
-    "vue-router": "^4.5.1",
-    "zod": "^3.25.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",
-    "@pinia/nuxt": "^0.4.11",
+    "nuxt": "^4.0.1",
     "vee-validate": "^4.12.6",
-    "chart.js": "^4.4.1"
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1",
+    "winston": "^3.17.0",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "autoprefixer": "^10.4.16",
+    "hardhat": "^2.22.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
-    "hardhat": "^2.22.0",
-    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   }

--- a/nuxt-app/server/middleware/logger.ts
+++ b/nuxt-app/server/middleware/logger.ts
@@ -1,0 +1,13 @@
+import logger from '../utils/logger'
+
+export default defineEventHandler((event) => {
+  const start = Date.now()
+
+  event.node.res.on('finish', () => {
+    const { method, url } = event.node.req
+    const { statusCode } = event.node.res
+    const duration = Date.now() - start
+    logger.info({ method, url, statusCode, duration }, 'request completed')
+  })
+})
+

--- a/nuxt-app/server/plugins/cron.ts
+++ b/nuxt-app/server/plugins/cron.ts
@@ -1,7 +1,8 @@
 import cron from 'node-cron'
+import logger from '../utils/logger'
 
 async function refreshMarketData() {
-    console.log('Refreshing market data or war-risk adjustments')
+    logger.info('Refreshing market data or war-risk adjustments')
     // TODO: implement actual refresh logic
 }
 

--- a/nuxt-app/server/utils/logger.ts
+++ b/nuxt-app/server/utils/logger.ts
@@ -1,0 +1,13 @@
+import winston from 'winston'
+
+const logger = winston.createLogger({
+  level: process.env.LOG_LEVEL || 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json()
+  ),
+  transports: [new winston.transports.Console()]
+})
+
+export default logger
+

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'nuxt'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['nuxt:3000']
+


### PR DESCRIPTION
## Summary
- add Winston-based logger and request middleware for Nuxt server
- pipe logs to stdout for container collection
- introduce Prometheus and Grafana services for basic monitoring

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898b3e95e04832eb58106619ed673e1