### PR TITLE
chore: add env-specific docker configs

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+CHAIN_RPC_URL=http://hardhat:8545
+JWT_SECRET=dev-secret
+ML_SERVICE_URL=http://localhost:8000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+CHAIN_RPC_URL=https://mainnet.example.com
+JWT_SECRET=prod-secret
+ML_SERVICE_URL=https://ml-service.example.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# KB Future Finance AI Challenge
+
+This project uses Docker Compose to run the Nuxt application and related services.
+
+## Environment Variables
+
+Define required variables in `.env.development` or `.env.production` depending on the environment:
+
+- `CHAIN_RPC_URL` – RPC endpoint for the blockchain network
+- `JWT_SECRET` – secret key for signing tokens
+- `ML_SERVICE_URL` – URL for the machine learning service
+
+## Development
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+The development configuration starts both the Nuxt app and a local Hardhat node.
+
+## Production
+
+```bash
+docker compose -f docker-compose.prod.yml up --build -d
+```
+
+The production configuration runs only the Nuxt app and expects external services.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,8 @@ services:
     build: ./nuxt-app
     ports:
       - "3000:3000"
-    environment:
-      CHAIN_RPC_URL: http://hardhat:8545
+    env_file:
+      - .env.development
     depends_on:
       - hardhat
   hardhat:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  nuxt:
+    build: ./nuxt-app
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.production


### PR DESCRIPTION
## Summary
- split docker services into development and production compose files
- add development and production environment variable templates
- document how to run each environment via Docker Compose

## Testing
- `docker compose version` *(fails: command not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898b3eaa588832eb42a1d27c04a7ba8