### PR TITLE
Add Hardhat escrow test and npm test script

### DIFF
--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -8,7 +8,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "test:contracts": "npx hardhat test"
   },
   "dependencies": {
     "better-sqlite3": "^9.4.3",

--- a/nuxt-app/test/escrow.test.ts
+++ b/nuxt-app/test/escrow.test.ts
@@ -1,0 +1,20 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("Escrow", function () {
+  it("allows the payer to deposit and release milestone funds", async function () {
+    const [payer, payee] = await ethers.getSigners();
+    const amounts = [ethers.parseEther("1")];
+    const Escrow = await ethers.getContractFactory("Escrow");
+    const escrow = await Escrow.deploy(payer.address, payee.address, amounts);
+    await escrow.waitForDeployment();
+
+    await escrow.connect(payer).deposit({ value: amounts[0] });
+    expect(await ethers.provider.getBalance(await escrow.getAddress())).to.equal(amounts[0]);
+
+    const payeeBalanceBefore = await ethers.provider.getBalance(payee.address);
+    await (await escrow.connect(payer).confirmMilestone(0)).wait();
+    const payeeBalanceAfter = await ethers.provider.getBalance(payee.address);
+    expect(payeeBalanceAfter).to.equal(payeeBalanceBefore + amounts[0]);
+  });
+});


### PR DESCRIPTION
## Summary
- add escrow contract test using Hardhat
- add npm script to run Hardhat tests

## Testing
- `npm run test:contracts` *(fails: Couldn't download compiler version list. Please check your internet connection and try again)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3ee2478832ebbb26dd22e363b55