### PR TITLE
Add FastAPI scoring service and model training pipeline

### DIFF
--- a/ml-service/.gitignore
+++ b/ml-service/.gitignore
@@ -1,0 +1,3 @@
+data/
+model.pkl
+__pycache__/

--- a/ml-service/Dockerfile
+++ b/ml-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ml-service/main.py
+++ b/ml-service/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from model import predict
+
+app = FastAPI()
+
+class ScoreRequest(BaseModel):
+    features: list[float]
+
+class ScoreResponse(BaseModel):
+    score: float
+
+@app.post("/score", response_model=ScoreResponse)
+def score_endpoint(req: ScoreRequest):
+    prediction = predict([req.features])[0]
+    return {"score": prediction}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ml-service/model.py
+++ b/ml-service/model.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import joblib
+from typing import List
+
+BASE_DIR = Path(__file__).resolve().parent
+MODEL_PATH = BASE_DIR / "model.pkl"
+_model = None
+
+def load_model():
+    global _model
+    if _model is None:
+        _model = joblib.load(MODEL_PATH)
+    return _model
+
+def predict(features: List[List[float]]):
+    model = load_model()
+    return model.predict(features).tolist()

--- a/ml-service/requirements.txt
+++ b/ml-service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pandas
+scikit-learn
+joblib

--- a/ml-service/scripts/generate_dummy_data.py
+++ b/ml-service/scripts/generate_dummy_data.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from sklearn.datasets import make_classification
+import pandas as pd
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DATA_DIR = BASE_DIR / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+FILE_PATH = DATA_DIR / "dummy_data.csv"
+
+def main():
+    X, y = make_classification(n_samples=100, n_features=4, n_informative=2,
+                               n_redundant=0, random_state=42)
+    df = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(X.shape[1])])
+    df["target"] = y
+    df.to_csv(FILE_PATH, index=False)
+
+if __name__ == "__main__":
+    main()

--- a/ml-service/train_model.py
+++ b/ml-service/train_model.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+import joblib
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_PATH = BASE_DIR / "data" / "dummy_data.csv"
+MODEL_PATH = BASE_DIR / "model.pkl"
+
+def main():
+    data = pd.read_csv(DATA_PATH)
+    X = data.drop("target", axis=1)
+    y = data["target"]
+    model = RandomForestClassifier(random_state=42)
+    model.fit(X, y)
+    joblib.dump(model, MODEL_PATH)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `ml-service` FastAPI app exposing `/score`
- add script to generate dummy data and training script for tree model
- include Dockerfile and requirements for containerization

## Testing
- `python ml-service/scripts/generate_dummy_data.py` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `python ml-service/train_model.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python ml-service/main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi uvicorn pandas scikit-learn joblib -i https://pypi.org/simple` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3ef0a70832eb9ec8bc9f6d674d4