### PR TITLE
feat: expose escrow chain status

### DIFF
--- a/nuxt-app/components/ChainStatus.vue
+++ b/nuxt-app/components/ChainStatus.vue
@@ -4,9 +4,14 @@
     <p v-if="deal.status">Status: {{ deal.status }}</p>
     <p v-if="deal.contract_address">Contract: {{ deal.contract_address }}</p>
     <p v-if="deal.contract_hash">Tx Hash: {{ deal.contract_hash }}</p>
+    <p v-if="chainStatus">Balance: {{ chainStatus.balance }}</p>
+    <p v-if="chainStatus">
+      Confirmed Milestones: {{ chainStatus.confirmedMilestones }} /
+      {{ chainStatus.totalMilestones }}
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{ deal: any }>()
+defineProps<{ deal: any; chainStatus?: { balance: string; confirmedMilestones: number; totalMilestones: number } }>()
 </script>

--- a/nuxt-app/pages/deals/[id].vue
+++ b/nuxt-app/pages/deals/[id].vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container-std section" v-if="deal">
     <h2 class="text-xl font-semibold mb-4">Deal {{ deal.id }}</h2>
-    <ChainStatus :deal="deal" class="mb-6" />
+    <ChainStatus :deal="deal" :chain-status="chainStatus" class="mb-6" />
     <div class="grid md:grid-cols-2 gap-4 mb-6">
       <RiskScoreCard :deal-id="deal.id" />
       <PremiumBreakdown :deal-id="deal.id" />
@@ -27,4 +27,5 @@ const { data, refresh } = await useFetch(`/api/deals/${id}`)
 
 const deal = computed(() => data.value?.deal)
 const milestones = computed(() => data.value?.milestones || [])
+const chainStatus = computed(() => data.value?.chainStatus)
 </script>

--- a/nuxt-app/server/api/deals/[id].get.ts
+++ b/nuxt-app/server/api/deals/[id].get.ts
@@ -1,6 +1,7 @@
 import { db, deals, dealMilestones, pricing, riskScores } from '~/server/utils/db'
 import { eq, asc } from 'drizzle-orm'
 import { createError } from 'h3'
+import { getEscrowStatus } from '~/server/utils/chain'
 
 export default defineEventHandler(async (event) => {
   const id = Number(event.context.params?.id)
@@ -40,11 +41,16 @@ export default defineEventHandler(async (event) => {
       }
     : undefined
 
+  const chainStatus = deal.contract_address
+    ? await getEscrowStatus(deal.contract_address, milestones.length)
+    : null
+
   return {
     deal,
     milestones,
     premium: pricingRow,
     riskScore: riskRow?.ml_score ?? null,
     riskSubScores,
+    chainStatus,
   }
 })

--- a/nuxt-app/server/utils/chain.ts
+++ b/nuxt-app/server/utils/chain.ts
@@ -49,6 +49,21 @@ export function getEscrow(address: string, signerOrProvider: Signer | JsonRpcPro
     return new Contract(address, escrowArtifact.abi, signerOrProvider)
 }
 
+export async function getEscrowStatus(address: string, milestoneCount = 0) {
+    const contract = getEscrow(address)
+    const balance: bigint = await contract.balance()
+    let confirmed = 0
+    for (let i = 0; i < milestoneCount; i++) {
+        const m = await contract.milestones(i)
+        if (m.released) confirmed++
+    }
+    return {
+        balance: balance.toString(),
+        confirmedMilestones: confirmed,
+        totalMilestones: milestoneCount,
+    }
+}
+
 export async function deployGuaranteeVault(signer: Signer) {
     if (!guaranteeArtifact) throw new Error('compile contracts first')
     const factory = new ContractFactory(guaranteeArtifact.abi, guaranteeArtifact.bytecode, signer)


### PR DESCRIPTION
## Summary
- add helper to fetch escrow contract balance and milestone confirmations
- return chain status from deals API
- display on-chain balance and milestone progress in ChainStatus component

## Testing
- `npm test --prefix nuxt-app` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898b3f02a34832ea078206ce9778c9a