### PR TITLE
chore: remove manual validation test and localize domains

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,7 +6,7 @@ const app = createApp();
 
 app.use('/api/risk/score', defineEventHandler(async (event) => {
   const body = await readBody(event);
-  const url = process.env.ML_SERVICE_URL || 'http://ml:8000/score';
+  const url = process.env.ML_SERVICE_URL || 'http://localhost:8000/score';
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -22,4 +22,4 @@ app.use('/api/risk/score', defineEventHandler(async (event) => {
 }));
 
 const server = createServer(toNodeListener(app));
-server.listen(3001);
+server.listen(3001, '0.0.0.0');

--- a/ml-service/validation.py
+++ b/ml-service/validation.py
@@ -58,8 +58,3 @@ def calculate_metrics(predictions: Iterable[int], actuals: Iterable[int]) -> Dic
         "mse": mse,
     }
 
-
-if __name__ == "__main__":  # pragma: no cover - simple manual test
-    # Example usage for quick manual verification
-    metrics = calculate_metrics([1, 0, 1, 1], [1, 0, 0, 1])
-    print(metrics)

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
   css: ['~/assets/tailwind.css'],
   modules: ['@pinia/nuxt', '@vee-validate/nuxt'],
   runtimeConfig: {
-    apiBase: process.env.API_BASE_URL || 'http://backend:3001'
+    apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
   },
   postcss: {
     plugins: {

--- a/nuxt-app/scripts/deploy.ts
+++ b/nuxt-app/scripts/deploy.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 async function main() {
-    const provider = new ethers.JsonRpcProvider(process.env.CHAIN_RPC_URL || 'http://127.0.0.1:8545')
+    const provider = new ethers.JsonRpcProvider(process.env.CHAIN_RPC_URL || 'http://localhost:8545')
     const signer = await provider.getSigner()
     console.log('Deploying contracts with account:', await signer.getAddress())
 

--- a/nuxt-app/server/utils/chain.ts
+++ b/nuxt-app/server/utils/chain.ts
@@ -3,7 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 export const provider = new JsonRpcProvider(
-    process.env.CHAIN_RPC_URL || 'http://127.0.0.1:8545',
+    process.env.CHAIN_RPC_URL || 'http://localhost:8545',
 )
 
 const escrowArtifactPath = path.join(process.cwd(), 'artifacts', 'contracts', 'Escrow.sol', 'Escrow.json')


### PR DESCRIPTION
## Summary
- remove inline manual test from `validation.py`
- point service URLs to localhost and bind backend to `0.0.0.0`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d544abd0832e9e5cd1d538357767