### PR TITLE
feat: improve deal creation and tracker

### DIFF
--- a/nuxt-app/pages/deal-tracker.vue
+++ b/nuxt-app/pages/deal-tracker.vue
@@ -13,7 +13,8 @@
           <span :class="['badge', status.time ? 'badge-ok' : (status.name === currentStatus ? 'badge-brand' : 'badge-warn')]">{{ status.time || 'pending' }}</span>
         </li>
       </ul>
-      <button class="btn btn-primary mb-6" @click="advance" :disabled="finished">Advance Status</button>
+      <button class="btn btn-primary mb-2" @click="advance" :disabled="finished">Advance Status</button>
+      <p v-if="finished" class="badge badge-ok mb-4">Deal completed</p>
       <h3 class="font-semibold mb-2">Payment History</h3>
       <div class="table-wrap">
         <table class="table">
@@ -48,9 +49,13 @@ const currentStatus = ref(flow[0])
 const finished = ref(false)
 const progressPercent = computed(() => (currentIndex.value / (flow.length - 1) * 100).toFixed(0) + '%')
 
-function advance() {
+async function advance() {
   const now = new Date().toISOString()
   statuses.value[currentIndex.value].time = now
+  await $fetch('/api/deal-tracker/advance', {
+    method: 'POST',
+    body: { status: currentStatus.value, time: now }
+  })
   if (currentIndex.value < flow.length - 1) {
     currentIndex.value++
     currentStatus.value = flow[currentIndex.value]

--- a/nuxt-app/server/api/deal-tracker/advance.post.ts
+++ b/nuxt-app/server/api/deal-tracker/advance.post.ts
@@ -1,0 +1,12 @@
+import { db, eventLogs } from '~/server/utils/db'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ status: string; time?: string }>(event)
+  await db.insert(eventLogs).values({
+    source: 'APP',
+    event_type: 'DEAL_STATUS',
+    message: `${body.status} ${body.time || ''}`.trim(),
+  })
+  return { ok: true }
+})
+


### PR DESCRIPTION
## Summary
- add validation and hash copy on deal creation page
- record deal status progression server-side and show completion indicator
- log tracker progress via new `/api/deal-tracker/advance` endpoint

## Testing
- `npm test` (fails: ERR_WORKER_UNSUPPORTED_OPERATION)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f99bd230832eaa8aea1e5f8938c5