### PR TITLE
Add on-chain insurance triggers and token flows

### DIFF
--- a/hardhat/contracts/ClaimNFT.sol
+++ b/hardhat/contracts/ClaimNFT.sol
@@ -1,23 +1,50 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+/// @title ClaimNFT - minimal NFT representing insurance claim certificates
+contract ClaimNFT {
+    string public constant name = "ClaimNFT";
+    string public constant symbol = "CLM";
 
-/// @title ClaimNFT - NFT representing insurance claim certificates
-contract ClaimNFT is ERC721URIStorage {
     uint256 public nextTokenId;
 
-    constructor() ERC721("ClaimNFT", "CLM") {}
+    struct Certificate {
+        uint256 dealId;
+        uint256 payoutAmount;
+    }
 
-    /// @notice Mint a new claim NFT to `to` with metadata `tokenURI`
+    mapping(uint256 => Certificate) public certificates;
+    mapping(uint256 => address) public ownerOf;
+    mapping(address => uint256) public balanceOf;
+    mapping(uint256 => string) private _tokenURIs;
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event CertificateIssued(uint256 indexed tokenId, uint256 indexed dealId, uint256 payoutAmount);
+
+    /// @notice Returns metadata URI for `tokenId`
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(ownerOf[tokenId] != address(0), "nonexistent token");
+        return _tokenURIs[tokenId];
+    }
+
+    /// @notice Mint a new claim certificate NFT
+    /// @param to Recipient of the NFT
+    /// @param dealId Related deal identifier
+    /// @param payoutAmount Amount paid out for the claim
+    /// @param uri Metadata URI describing the claim
     /// @return tokenId The newly issued token id
-    function issue(address to, string memory tokenURI)
-        external
-        returns (uint256 tokenId)
-    {
+    function issueCertificate(
+        address to,
+        uint256 dealId,
+        uint256 payoutAmount,
+        string memory uri
+    ) external returns (uint256 tokenId) {
         tokenId = ++nextTokenId;
-        _safeMint(to, tokenId);
-        _setTokenURI(tokenId, tokenURI);
+        ownerOf[tokenId] = to;
+        balanceOf[to] += 1;
+        _tokenURIs[tokenId] = uri;
+        certificates[tokenId] = Certificate(dealId, payoutAmount);
+        emit Transfer(address(0), to, tokenId);
+        emit CertificateIssued(tokenId, dealId, payoutAmount);
     }
 }
-

--- a/hardhat/contracts/Escrow.sol
+++ b/hardhat/contracts/Escrow.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 contract Escrow {
     address public payer;
     address public payee;
+    address public insurer;
+    uint256 public dealId;
 
     struct Milestone {
         uint256 amount;
@@ -11,14 +13,27 @@ contract Escrow {
     }
 
     Milestone[] public milestones;
+    bool public cancelled;
+    bool public defaultDeclared;
 
     event Deposited(address indexed from, uint256 amount);
     event MilestoneConfirmed(uint256 indexed index);
     event FundsReleased(uint256 amount);
+    event DealCancelled(uint256 indexed dealId, address indexed by);
+    event DefaultDeclared(uint256 indexed dealId, address indexed by);
+    event ClaimIssued(uint256 indexed dealId, address indexed by);
 
-    constructor(address _payer, address _payee, uint256[] memory _amounts) {
+    constructor(
+        uint256 _dealId,
+        address _payer,
+        address _payee,
+        address _insurer,
+        uint256[] memory _amounts
+    ) {
+        dealId = _dealId;
         payer = _payer;
         payee = _payee;
+        insurer = _insurer;
         for (uint i = 0; i < _amounts.length; i++) {
             milestones.push(Milestone({ amount: _amounts[i], released: false }));
         }
@@ -31,6 +46,7 @@ contract Escrow {
 
     function confirmMilestone(uint index) external {
         require(msg.sender == payer, 'only payer');
+        require(!cancelled && !defaultDeclared, 'deal ended');
         Milestone storage m = milestones[index];
         require(!m.released, 'already released');
         require(address(this).balance >= m.amount, 'insufficient');
@@ -42,6 +58,7 @@ contract Escrow {
 
     function releaseFunds() external {
         require(msg.sender == payer, 'only payer');
+        require(!cancelled && !defaultDeclared, 'deal ended');
         uint bal = address(this).balance;
         payable(payee).transfer(bal);
         emit FundsReleased(bal);
@@ -49,5 +66,28 @@ contract Escrow {
 
     function balance() external view returns (uint) {
         return address(this).balance;
+    }
+
+    /// @notice Cancels the deal and refunds remaining balance to the payer
+    function cancelDeal() external {
+        require(msg.sender == payer || msg.sender == payee, 'only parties');
+        require(!cancelled && !defaultDeclared, 'deal ended');
+        cancelled = true;
+        uint bal = address(this).balance;
+        if (bal > 0) {
+            payable(payer).transfer(bal);
+            emit FundsReleased(bal);
+        }
+        emit DealCancelled(dealId, msg.sender);
+        emit ClaimIssued(dealId, msg.sender);
+    }
+
+    /// @notice Declare default and trigger insurance claim event
+    function declareDefault() external {
+        require(msg.sender == payer || msg.sender == payee, 'only parties');
+        require(!cancelled && !defaultDeclared, 'deal ended');
+        defaultDeclared = true;
+        emit DefaultDeclared(dealId, msg.sender);
+        emit ClaimIssued(dealId, msg.sender);
     }
 }

--- a/hardhat/contracts/GuaranteeVault.sol
+++ b/hardhat/contracts/GuaranteeVault.sol
@@ -1,30 +1,43 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "./IERC20.sol";
+
+/// @title GuaranteeVault - manages guarantor limits and locked funds
 contract GuaranteeVault {
+    IERC20 public immutable token;
+
     mapping(address => uint256) public limits;
     mapping(uint256 => uint256) public locked;
 
     event GuaranteeLimitSet(address indexed account, uint256 limit);
     event Locked(uint256 indexed dealId, uint256 amount);
-    event Unlocked(uint256 indexed dealId, uint256 amount);
+    event Unlocked(uint256 indexed dealId, uint256 amount, address to);
+
+    constructor(address tokenAddress) {
+        token = IERC20(tokenAddress);
+    }
 
     function setGuaranteeLimit(address account, uint256 limit) external {
         limits[account] = limit;
         emit GuaranteeLimitSet(account, limit);
     }
 
+    /// @notice Locks `amount` of tokens from the caller for deal `dealId`
     function lock(uint256 dealId, uint256 amount) external {
         require(amount <= limits[msg.sender], 'limit exceeded');
         locked[dealId] += amount;
         limits[msg.sender] -= amount;
+        require(token.transferFrom(msg.sender, address(this), amount), 'transfer failed');
         emit Locked(dealId, amount);
     }
 
-    function unlock(uint256 dealId, uint256 amount) external {
+    /// @notice Unlocks `amount` for deal `dealId` and transfers tokens to `to`
+    function unlock(uint256 dealId, uint256 amount, address to) external {
         require(locked[dealId] >= amount, 'not locked');
         locked[dealId] -= amount;
         limits[msg.sender] += amount;
-        emit Unlocked(dealId, amount);
+        require(token.transfer(to, amount), 'transfer failed');
+        emit Unlocked(dealId, amount, to);
     }
 }

--- a/hardhat/contracts/IERC20.sol
+++ b/hardhat/contracts/IERC20.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/nuxt-app/contracts/GuaranteeVault.sol
+++ b/nuxt-app/contracts/GuaranteeVault.sol
@@ -1,30 +1,43 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "./IERC20.sol";
+
+/// @title GuaranteeVault - manages guarantor limits and locked funds backed by tokens
 contract GuaranteeVault {
+    IERC20 public immutable token;
+
     mapping(address => uint256) public limits;
     mapping(uint256 => uint256) public locked;
 
     event GuaranteeLimitSet(address indexed account, uint256 limit);
     event Locked(uint256 indexed dealId, uint256 amount);
-    event Unlocked(uint256 indexed dealId, uint256 amount);
+    event Unlocked(uint256 indexed dealId, uint256 amount, address to);
+
+    constructor(address tokenAddress) {
+        token = IERC20(tokenAddress);
+    }
 
     function setGuaranteeLimit(address account, uint256 limit) external {
         limits[account] = limit;
         emit GuaranteeLimitSet(account, limit);
     }
 
+    /// @notice Locks `amount` of tokens from the caller for deal `dealId`
     function lock(uint256 dealId, uint256 amount) external {
         require(amount <= limits[msg.sender], 'limit exceeded');
         locked[dealId] += amount;
         limits[msg.sender] -= amount;
+        require(token.transferFrom(msg.sender, address(this), amount), 'transfer failed');
         emit Locked(dealId, amount);
     }
 
-    function unlock(uint256 dealId, uint256 amount) external {
+    /// @notice Unlocks `amount` and transfers to `to`
+    function unlock(uint256 dealId, uint256 amount, address to) external {
         require(locked[dealId] >= amount, 'not locked');
         locked[dealId] -= amount;
         limits[msg.sender] += amount;
-        emit Unlocked(dealId, amount);
+        require(token.transfer(to, amount), 'transfer failed');
+        emit Unlocked(dealId, amount, to);
     }
 }

--- a/nuxt-app/contracts/IERC20.sol
+++ b/nuxt-app/contracts/IERC20.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/nuxt-app/contracts/InsurancePool.sol
+++ b/nuxt-app/contracts/InsurancePool.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "./IERC20.sol";
+
+/// @title InsurancePool - collects premiums and pays out claims
 contract InsurancePool {
+    IERC20 public immutable token;
+
     struct Deal {
         address insured;
         uint256 premium;
@@ -10,15 +15,31 @@ contract InsurancePool {
     mapping(uint256 => Deal) public deals;
 
     event DealRegistered(uint256 indexed dealId, address insured, uint256 premium);
+    event PoolFunded(address indexed from, uint256 amount);
     event PayoutTriggered(uint256 indexed dealId, address to, uint256 amount);
 
-    function registerDeal(uint256 dealId, address insured, uint256 premium) external {
-        deals[dealId] = Deal(insured, premium);
-        emit DealRegistered(dealId, insured, premium);
+    constructor(address tokenAddress) {
+        token = IERC20(tokenAddress);
     }
 
+    /// @notice Deposit additional funds to the pool
+    function fundPool(uint256 amount) external {
+        require(token.transferFrom(msg.sender, address(this), amount), 'transfer failed');
+        emit PoolFunded(msg.sender, amount);
+    }
+
+    /// @notice Register a new deal and collect premium
+    function registerDeal(uint256 dealId, uint256 premium) external {
+        deals[dealId] = Deal(msg.sender, premium);
+        require(token.transferFrom(msg.sender, address(this), premium), 'transfer failed');
+        emit DealRegistered(dealId, msg.sender, premium);
+    }
+
+    /// @notice Pay out a claim from the pool
     function triggerPayout(uint256 dealId, address to, uint256 amount) external {
         require(deals[dealId].insured != address(0), 'unknown deal');
+        require(token.balanceOf(address(this)) >= amount, 'insufficient pool');
+        require(token.transfer(to, amount), 'transfer failed');
         emit PayoutTriggered(dealId, to, amount);
     }
 }


### PR DESCRIPTION
## Summary
- extend Escrow with cancellation and default logic that emits ClaimIssued for insurance
- handle token locking/unlocking in GuaranteeVault via ERC20 transfers
- manage premiums, pool funding, and payouts in InsurancePool
- replace OpenZeppelin with minimal local interfaces and ClaimNFT implementation

## Testing
- `npx hardhat compile` *(fails: couldn't download Solidity compiler, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a423c359c832e8d113c3a7c083002