### PR TITLE
feat: add oracle listener and claim request endpoint

### DIFF
--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -11,7 +11,8 @@
     "test": "vitest",
     "test:e2e": "cypress run",
     "test:api": "vitest run",
-    "test:contracts": "npx hardhat test"
+    "test:contracts": "npx hardhat test",
+    "oracle:listen": "node --loader ts-node/esm server/workers/oracle-listener.ts"
   },
   "dependencies": {
     "@pinia/nuxt": "^0.4.11",

--- a/nuxt-app/server/api/claim/request.post.ts
+++ b/nuxt-app/server/api/claim/request.post.ts
@@ -1,0 +1,35 @@
+import { db, deals, eventLogs, payoutRequests } from '~/server/utils/db'
+import { eq } from 'drizzle-orm'
+import { createError } from 'h3'
+import { broadcastClaim } from './stream'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ dealId?: number; amount?: number; reason?: string }>(event)
+  const dealId = body?.dealId
+  if (typeof dealId !== 'number') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid dealId' })
+  }
+  const amount = typeof body.amount === 'number' ? body.amount : 0
+  const reason = body.reason || 'Claim issued'
+  const now = new Date().toISOString()
+  await db.transaction(async (tx) => {
+    await tx
+      .update(deals)
+      .set({ status: 'CLAIM_ISSUED', updated_at: now })
+      .where(eq(deals.id, dealId))
+    await tx.insert(eventLogs).values({
+      deal_id: dealId,
+      source: 'APP',
+      event_type: 'CLAIM',
+      message: reason,
+      created_at: now,
+    })
+    await tx.insert(payoutRequests).values({
+      deal: String(dealId),
+      amount,
+      status: 'REQUESTED',
+    })
+  })
+  broadcastClaim({ dealId, amount, reason, ts: Date.now() })
+  return { success: true }
+})

--- a/nuxt-app/server/api/claim/stream.ts
+++ b/nuxt-app/server/api/claim/stream.ts
@@ -1,0 +1,40 @@
+import { eventHandler, setHeader } from 'h3'
+import { Readable } from 'node:stream'
+
+interface ClaimEvent {
+  dealId: number
+  amount: number
+  reason: string
+  ts: number
+}
+
+const clients = new Set<Readable>()
+let latest: ClaimEvent | null = null
+
+export const broadcastClaim = (data: ClaimEvent) => {
+  latest = data
+  const payload = `data: ${JSON.stringify(data)}\n\n`
+  for (const stream of clients) {
+    stream.push(payload)
+  }
+}
+
+export default eventHandler((event) => {
+  setHeader(event, 'Content-Type', 'text/event-stream')
+  setHeader(event, 'Cache-Control', 'no-cache')
+  setHeader(event, 'Connection', 'keep-alive')
+
+  const stream = new Readable({ read() {} })
+  clients.add(stream)
+
+  if (latest) {
+    stream.push(`data: ${JSON.stringify(latest)}\n\n`)
+  }
+
+  event.node.req.on('close', () => {
+    clients.delete(stream)
+    stream.push(null)
+  })
+
+  return stream
+})

--- a/nuxt-app/server/api/oracle/geopolitical.post.ts
+++ b/nuxt-app/server/api/oracle/geopolitical.post.ts
@@ -1,0 +1,28 @@
+import { db, stats, eventLogs } from '~/server/utils/db'
+import { createError } from 'h3'
+import { eq } from 'drizzle-orm'
+import { broadcastGeo } from './geopolitical/stream'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ region: string; level: number; ts: number }>(event)
+  const { region, level, ts } = body || {}
+  if (typeof region !== 'string' || typeof level !== 'number' || typeof ts !== 'number') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid payload' })
+  }
+  await db.transaction(async (tx) => {
+    const key = 'geopolitical_risk'
+    const row = await tx.select().from(stats).where(eq(stats.key, key)).get()
+    if (row) {
+      await tx.update(stats).set({ value: String(level) }).where(eq(stats.key, key))
+    } else {
+      await tx.insert(stats).values({ key, value: String(level) })
+    }
+    await tx.insert(eventLogs).values({
+      source: 'ORACLE',
+      event_type: 'ORACLE',
+      message: JSON.stringify({ type: 'GEOPOLITICAL', region, level, ts })
+    })
+  })
+  broadcastGeo({ region, level, ts })
+  return { geopolitical_risk: level }
+})

--- a/nuxt-app/server/api/oracle/geopolitical/stream.ts
+++ b/nuxt-app/server/api/oracle/geopolitical/stream.ts
@@ -1,0 +1,39 @@
+import { eventHandler, setHeader } from 'h3'
+import { Readable } from 'node:stream'
+
+interface GeoUpdate {
+  region: string
+  level: number
+  ts: number
+}
+
+const clients = new Set<Readable>()
+let latest: GeoUpdate | null = null
+
+export const broadcastGeo = (data: GeoUpdate) => {
+  latest = data
+  const payload = `data: ${JSON.stringify(data)}\n\n`
+  for (const stream of clients) {
+    stream.push(payload)
+  }
+}
+
+export default eventHandler((event) => {
+  setHeader(event, 'Content-Type', 'text/event-stream')
+  setHeader(event, 'Cache-Control', 'no-cache')
+  setHeader(event, 'Connection', 'keep-alive')
+
+  const stream = new Readable({ read() {} })
+  clients.add(stream)
+
+  if (latest) {
+    stream.push(`data: ${JSON.stringify(latest)}\n\n`)
+  }
+
+  event.node.req.on('close', () => {
+    clients.delete(stream)
+    stream.push(null)
+  })
+
+  return stream
+})

--- a/nuxt-app/server/api/oracle/weather.post.ts
+++ b/nuxt-app/server/api/oracle/weather.post.ts
@@ -1,0 +1,28 @@
+import { db, stats, eventLogs } from '~/server/utils/db'
+import { createError } from 'h3'
+import { eq } from 'drizzle-orm'
+import { broadcastWeather } from './weather/stream'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ location: string; severity: number; ts: number }>(event)
+  const { location, severity, ts } = body || {}
+  if (typeof location !== 'string' || typeof severity !== 'number' || typeof ts !== 'number') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid payload' })
+  }
+  await db.transaction(async (tx) => {
+    const key = 'weather_risk'
+    const row = await tx.select().from(stats).where(eq(stats.key, key)).get()
+    if (row) {
+      await tx.update(stats).set({ value: String(severity) }).where(eq(stats.key, key))
+    } else {
+      await tx.insert(stats).values({ key, value: String(severity) })
+    }
+    await tx.insert(eventLogs).values({
+      source: 'ORACLE',
+      event_type: 'ORACLE',
+      message: JSON.stringify({ type: 'WEATHER', location, severity, ts })
+    })
+  })
+  broadcastWeather({ location, severity, ts })
+  return { weather_risk: severity }
+})

--- a/nuxt-app/server/api/oracle/weather/stream.ts
+++ b/nuxt-app/server/api/oracle/weather/stream.ts
@@ -1,0 +1,42 @@
+import { eventHandler, setHeader } from 'h3'
+import { Readable } from 'node:stream'
+
+interface WeatherUpdate {
+  location: string
+  severity: number
+  ts: number
+}
+
+const clients = new Set<Readable>()
+let latest: WeatherUpdate | null = null
+
+export const broadcastWeather = (data: WeatherUpdate) => {
+  latest = data
+  const payload = `data: ${JSON.stringify(data)}\n\n`
+  for (const stream of clients) {
+    stream.push(payload)
+  }
+}
+
+export default eventHandler((event) => {
+  setHeader(event, 'Content-Type', 'text/event-stream')
+  setHeader(event, 'Cache-Control', 'no-cache')
+  setHeader(event, 'Connection', 'keep-alive')
+
+  const stream = new Readable({
+    read() {}
+  })
+
+  clients.add(stream)
+
+  if (latest) {
+    stream.push(`data: ${JSON.stringify(latest)}\n\n`)
+  }
+
+  event.node.req.on('close', () => {
+    clients.delete(stream)
+    stream.push(null)
+  })
+
+  return stream
+})

--- a/nuxt-app/server/workers/oracle-listener.ts
+++ b/nuxt-app/server/workers/oracle-listener.ts
@@ -1,0 +1,213 @@
+import { provider, getEscrow, getGuaranteeVault, getInsurancePool } from '../utils/chain'
+import { db, eventLogs, dealMilestones, deals, payoutRequests, stats } from '../utils/db'
+import { and, eq } from 'drizzle-orm'
+
+async function watchEscrow(dealId: number, address: string) {
+  const escrow = getEscrow(address, provider)
+  escrow.on('Deposited', async (from, value) => {
+    const amount = Number(value.toString())
+    await db.transaction(async (tx) => {
+      const row = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'escrow_balance'))
+        .get()
+      const bal = Number(row?.value || 0) + amount
+      await tx
+        .update(stats)
+        .set({ value: String(bal) })
+        .where(eq(stats.key, 'escrow_balance'))
+      await tx.insert(eventLogs).values({
+        deal_id: dealId,
+        source: 'CHAIN',
+        event_type: 'Deposited',
+        message: JSON.stringify({ from, amount: amount.toString() })
+      })
+    })
+  })
+  escrow.on('MilestoneConfirmed', async (idx) => {
+    const now = new Date().toISOString()
+    await db.transaction(async (tx) => {
+      await tx.update(dealMilestones)
+        .set({ status: 'CONFIRMED', confirmed_at: now })
+        .where(and(eq(dealMilestones.deal_id, dealId), eq(dealMilestones.ord, Number(idx))))
+      await tx.insert(eventLogs).values({
+        deal_id: dealId,
+        source: 'CHAIN',
+        event_type: 'MilestoneConfirmed',
+        message: JSON.stringify({ index: Number(idx) })
+      })
+    })
+  })
+  escrow.on('FundsReleased', async (value) => {
+    const amount = Number(value.toString())
+    await db.transaction(async (tx) => {
+      const escrowRow = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'escrow_balance'))
+        .get()
+      const sellerRow = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'seller_balance'))
+        .get()
+      const escrowBal = Number(escrowRow?.value || 0) - amount
+      const sellerBal = Number(sellerRow?.value || 0) + amount
+      await tx
+        .update(stats)
+        .set({ value: String(escrowBal) })
+        .where(eq(stats.key, 'escrow_balance'))
+      await tx
+        .update(stats)
+        .set({ value: String(sellerBal) })
+        .where(eq(stats.key, 'seller_balance'))
+      await tx.insert(eventLogs).values({
+        deal_id: dealId,
+        source: 'CHAIN',
+        event_type: 'FundsReleased',
+        message: JSON.stringify({ amount: amount.toString() })
+      })
+    })
+  })
+}
+
+async function watchInsurance(address: string) {
+  const pool = getInsurancePool(address, provider)
+  pool.on('DealRegistered', async (dealId, insured, premium) => {
+    const id = Number(dealId)
+    const amount = Number(premium.toString())
+    const now = new Date().toISOString()
+    await db.transaction(async (tx) => {
+      await tx
+        .update(deals)
+        .set({ status: 'INSURED', updated_at: now })
+        .where(eq(deals.id, id))
+      const row = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'pool_balance'))
+        .get()
+      const bal = Number(row?.value || 0) + amount
+      await tx
+        .update(stats)
+        .set({ value: String(bal) })
+        .where(eq(stats.key, 'pool_balance'))
+      await tx.insert(eventLogs).values({
+        deal_id: id,
+        source: 'CHAIN',
+        event_type: 'DealRegistered',
+        message: JSON.stringify({ insured, premium: premium.toString() })
+      })
+    })
+  })
+  pool.on('PayoutTriggered', async (dealId, to, amount) => {
+    const id = Number(dealId)
+    const amt = Number(amount.toString())
+    const now = new Date().toISOString()
+    await db.transaction(async (tx) => {
+      await tx
+        .update(deals)
+        .set({ status: 'PAYOUT_TRIGGERED', updated_at: now })
+        .where(eq(deals.id, id))
+      await tx.insert(eventLogs).values({
+        deal_id: id,
+        source: 'CHAIN',
+        event_type: 'PayoutTriggered',
+        message: JSON.stringify({ to, amount: amount.toString() })
+      })
+      await tx.insert(payoutRequests).values({
+        deal: String(id),
+        amount: amt,
+        status: 'PAYOUT_TRIGGERED'
+      })
+      const poolRow = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'pool_balance'))
+        .get()
+      const poolBal = Number(poolRow?.value || 0) - amt
+      await tx
+        .update(stats)
+        .set({ value: String(poolBal) })
+        .where(eq(stats.key, 'pool_balance'))
+      const claimRow = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'claims'))
+        .get()
+      const claimCount = Number(claimRow?.value || 0) + 1
+      await tx
+        .update(stats)
+        .set({ value: String(claimCount) })
+        .where(eq(stats.key, 'claims'))
+    })
+  })
+}
+
+async function watchGuarantee(address: string) {
+  const vault = getGuaranteeVault(address, provider)
+  vault.on('Locked', async (dealId, amount) => {
+    const amt = Number(amount.toString())
+    await db.transaction(async (tx) => {
+      const row = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'vault_balance'))
+        .get()
+      const bal = Number(row?.value || 0) + amt
+      await tx
+        .update(stats)
+        .set({ value: String(bal) })
+        .where(eq(stats.key, 'vault_balance'))
+      await tx.insert(eventLogs).values({
+        deal_id: Number(dealId),
+        source: 'CHAIN',
+        event_type: 'Locked',
+        message: JSON.stringify({ amount: amt.toString() })
+      })
+    })
+  })
+  vault.on('Unlocked', async (dealId, amount) => {
+    const amt = Number(amount.toString())
+    await db.transaction(async (tx) => {
+      const row = await tx
+        .select()
+        .from(stats)
+        .where(eq(stats.key, 'vault_balance'))
+        .get()
+      const bal = Number(row?.value || 0) - amt
+      await tx
+        .update(stats)
+        .set({ value: String(bal) })
+        .where(eq(stats.key, 'vault_balance'))
+      await tx.insert(eventLogs).values({
+        deal_id: Number(dealId),
+        source: 'CHAIN',
+        event_type: 'Unlocked',
+        message: JSON.stringify({ amount: amt.toString() })
+      })
+    })
+  })
+}
+
+async function main() {
+  const allDeals = await db.select().from(deals).all()
+  for (const d of allDeals) {
+    if (d.contract_address) {
+      watchEscrow(d.id, d.contract_address)
+    }
+  }
+  if (process.env.INSURANCE_POOL_ADDRESS) {
+    watchInsurance(process.env.INSURANCE_POOL_ADDRESS)
+  }
+  if (process.env.GUARANTEE_VAULT_ADDRESS) {
+    watchGuarantee(process.env.GUARANTEE_VAULT_ADDRESS)
+  }
+  console.log('Oracle listener started')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add API endpoint to record claim requests and create payout entries
- introduce weather and geopolitical risk oracle endpoints and SSE streams
- implement worker to listen for on-chain events and update DB; add script to run listener
- broadcast claim requests in real time and sync on-chain balances to stats

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined; TypeError: process.chdir() is not supported in workers)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c3147c4832e97d444d7e6d841ef