### PR TITLE
feat: enhance auth and rbac

### DIFF
--- a/nuxt-app/pages/deal-tracker.vue
+++ b/nuxt-app/pages/deal-tracker.vue
@@ -40,6 +40,8 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+
+definePageMeta({ roles: ['buyer', 'seller', 'admin'] })
 interface Status { name: string; time?: string }
 
 const flow = ['INITIATED', 'FUNDED', 'IN_TRANSIT', 'ARRIVED', 'INSPECTING', 'ACCEPTED']

--- a/nuxt-app/pages/guarantor.vue
+++ b/nuxt-app/pages/guarantor.vue
@@ -45,6 +45,8 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+definePageMeta({ roles: ['guarantor'] })
+
 const { data: statsData, refresh: refreshStats } = await useFetch('/api/stats', {
   params: { keys: 'guarantee_limit,guarantee_balance' },
 })

--- a/nuxt-app/pages/insurer.vue
+++ b/nuxt-app/pages/insurer.vue
@@ -41,6 +41,8 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+definePageMeta({ roles: ['insurer'] })
+
 const { data: statsData } = await useFetch('/api/stats', { params: { keys: 'pool_balance' } })
 const poolBalance = computed(() => Number(statsData.value?.pool_balance || 0))
 const coverage = ref(80)

--- a/nuxt-app/pages/risk-analysis.vue
+++ b/nuxt-app/pages/risk-analysis.vue
@@ -63,6 +63,8 @@
 import { reactive, ref, computed } from 'vue'
 import PremiumBreakdown from "~/components/PremiumBreakdown.vue";
 
+definePageMeta({ roles: ['buyer', 'insurer'] })
+
 const input = reactive({ counterparty: '', goods: '', route: '' })
 const score = ref(0)
 const breakdown = ref<null | {

--- a/nuxt-app/server/api/auth/logout.post.ts
+++ b/nuxt-app/server/api/auth/logout.post.ts
@@ -1,1 +1,7 @@
-export default defineEventHandler(() => ({ ok: true }))
+import { setCookie } from 'h3'
+
+export default defineEventHandler((event) => {
+  setCookie(event, 'refresh', '', { httpOnly: true, maxAge: 0, path: '/' })
+  return { ok: true }
+})
+

--- a/nuxt-app/server/api/auth/nonce.get.ts
+++ b/nuxt-app/server/api/auth/nonce.get.ts
@@ -1,0 +1,12 @@
+import { getQuery, createError } from 'h3'
+import { generateNonce } from '../../utils/auth'
+
+export default defineEventHandler((event) => {
+  const { address } = getQuery(event)
+  if (!address || typeof address !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'address required' })
+  }
+  const nonce = generateNonce(address)
+  return { nonce }
+})
+

--- a/nuxt-app/server/api/auth/otp/verify.post.ts
+++ b/nuxt-app/server/api/auth/otp/verify.post.ts
@@ -1,4 +1,4 @@
-import { readBody, createError } from 'h3'
+import { readBody, createError, setCookie } from 'h3'
 import { verifyOtp, findOrCreateUser, issueTokens } from '../../../utils/auth'
 
 export default defineEventHandler(async (event) => {
@@ -9,5 +9,10 @@ export default defineEventHandler(async (event) => {
   }
   const { user, roles } = await findOrCreateUser(email, name)
   const tokens = issueTokens(user, roles)
-  return tokens
+  setCookie(event, 'refresh', tokens.refresh, {
+    httpOnly: true,
+    maxAge: 14 * 24 * 3600,
+    path: '/',
+  })
+  return { access: tokens.access }
 })

--- a/nuxt-app/server/api/auth/refresh.post.ts
+++ b/nuxt-app/server/api/auth/refresh.post.ts
@@ -1,10 +1,10 @@
-import { readBody, createError } from 'h3'
+import { readBody, createError, getCookie, setCookie } from 'h3'
 import jwt from 'jsonwebtoken'
 import { getUserWithRoles, issueTokens } from '../../utils/auth'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
-  const { refresh } = body
+  const refresh = getCookie(event, 'refresh') || body.refresh
   try {
     const payload: any = jwt.verify(refresh, process.env.REFRESH_SECRET || 'refresh')
     const data = getUserWithRoles(payload.id)
@@ -12,7 +12,12 @@ export default defineEventHandler(async (event) => {
       throw new Error('user not found')
     }
     const tokens = issueTokens(data.user, data.roles)
-    return tokens
+    setCookie(event, 'refresh', tokens.refresh, {
+      httpOnly: true,
+      maxAge: 14 * 24 * 3600,
+      path: '/',
+    })
+    return { access: tokens.access }
   } catch {
     throw createError({ statusCode: 401, statusMessage: 'Invalid refresh token' })
   }

--- a/nuxt-app/server/api/auth/siwe/verify.post.ts
+++ b/nuxt-app/server/api/auth/siwe/verify.post.ts
@@ -1,0 +1,23 @@
+import { readBody, createError, setCookie } from 'h3'
+import { verifySiwe, findOrCreateUserByWallet, issueTokens } from '../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const address = body.address as string
+  const signature = body.signature as string
+  if (!address || !signature) {
+    throw createError({ statusCode: 400, statusMessage: 'address and signature required' })
+  }
+  if (!verifySiwe(address, signature)) {
+    throw createError({ statusCode: 401, statusMessage: 'Invalid signature' })
+  }
+  const { user, roles } = await findOrCreateUserByWallet(address)
+  const tokens = issueTokens(user, roles)
+  setCookie(event, 'refresh', tokens.refresh, {
+    httpOnly: true,
+    maxAge: 14 * 24 * 3600,
+    path: '/',
+  })
+  return { access: tokens.access }
+})
+

--- a/nuxt-app/server/api/claim/distribute.post.ts
+++ b/nuxt-app/server/api/claim/distribute.post.ts
@@ -1,9 +1,11 @@
 import { db, eventLogs, stats, deals } from '~/server/utils/db'
 import { eq } from 'drizzle-orm'
 import { issueClaimNFT } from './issueNFT.post'
-import { createError } from 'h3'
+import { createError, readBody } from 'h3'
+import { authGuard } from '../../utils/auth'
 
 export default defineEventHandler(async (event) => {
+  await authGuard(event, ['admin'])
   const body = await readBody<{ step: number; dealId?: number; amount?: number }>(event)
   const step = body.step ?? 0
   const dealId = body.dealId ?? 1

--- a/nuxt-app/server/api/claim/issueNFT.post.ts
+++ b/nuxt-app/server/api/claim/issueNFT.post.ts
@@ -1,5 +1,7 @@
 import { db, eventLogs, claimNfts } from '~/server/utils/db'
 import { getClaimNFT, provider } from '~/server/utils/chain'
+import { authGuard } from '../../utils/auth'
+import { readBody } from 'h3'
 
 /**
  * Mint a Claim NFT either on-chain (if CLAIM_NFT_ADDRESS is set) or generate
@@ -36,6 +38,7 @@ export async function issueClaimNFT(dealId: number, metadata = '') {
 }
 
 export default defineEventHandler(async (event) => {
+  await authGuard(event, ['admin'])
   const body = await readBody<{ dealId: number; metadata?: string }>(event)
   const tokenId = await issueClaimNFT(body.dealId ?? 0, body.metadata)
   return { id: tokenId }

--- a/nuxt-app/server/api/deal-tracker/advance.post.ts
+++ b/nuxt-app/server/api/deal-tracker/advance.post.ts
@@ -1,6 +1,9 @@
 import { db, eventLogs } from '~/server/utils/db'
+import { authGuard } from '../../utils/auth'
+import { readBody } from 'h3'
 
 export default defineEventHandler(async (event) => {
+  await authGuard(event, ['buyer', 'seller', 'admin'])
   const body = await readBody<{ status: string; time?: string }>(event)
   await db.insert(eventLogs).values({
     source: 'APP',

--- a/nuxt-app/server/api/deals/index.post.ts
+++ b/nuxt-app/server/api/deals/index.post.ts
@@ -1,7 +1,9 @@
+import { readBody } from 'h3'
 import { db, deals, dealMilestones, stats, pricing, eventLogs } from '~/server/utils/db'
 import { z } from 'zod'
 import { deployEscrow, provider, getGuaranteeVault, getInsurancePool } from '~/server/utils/chain'
 import { eq } from 'drizzle-orm'
+import { authGuard } from '~/server/utils/auth'
 
 const schema = z.object({
   amount: z.number().positive(),
@@ -22,6 +24,7 @@ const schema = z.object({
 })
 
 export default defineEventHandler(async (event) => {
+  await authGuard(event, ['buyer'])
   const body = await readBody(event)
   const data = schema.parse(body)
 

--- a/nuxt-app/server/api/pricing/quote.post.ts
+++ b/nuxt-app/server/api/pricing/quote.post.ts
@@ -4,7 +4,7 @@ import { db, pricing, riskScores } from '../../utils/db'
 import { eq, desc } from 'drizzle-orm'
 
 export default defineEventHandler(async (event) => {
-  await authGuard(event)
+  await authGuard(event, ['buyer', 'insurer'])
   const body = await readBody(event)
   const { deal_id, base_rate, market_adjustment = 0, amount } = body
   const rs = db

--- a/nuxt-app/server/api/risk/score.post.ts
+++ b/nuxt-app/server/api/risk/score.post.ts
@@ -3,7 +3,7 @@ import { authGuard } from '../../utils/auth'
 import { db, riskScores } from '../../utils/db'
 
 export default defineEventHandler(async (event) => {
-  await authGuard(event)
+  await authGuard(event, ['buyer', 'insurer'])
   const body = await readBody(event)
   const { deal_id, features } = body
   const url = process.env.ML_SERVICE_URL || 'http://localhost:3001/api/risk/score'

--- a/nuxt-app/server/utils/auth.ts
+++ b/nuxt-app/server/utils/auth.ts
@@ -1,9 +1,11 @@
 import { getRequestHeader, createError } from 'h3'
 import jwt from 'jsonwebtoken'
+import { verifyMessage } from 'ethers'
 import { db, users, roles, userRoles } from './db'
 import { eq } from 'drizzle-orm'
 
 const otpStore = new Map<string, string>()
+const nonceStore = new Map<string, string>()
 
 export function generateOtp(email: string) {
   const code = Math.floor(100000 + Math.random() * 900000).toString()
@@ -15,6 +17,26 @@ export function generateOtp(email: string) {
 export function verifyOtp(email: string, code: string) {
   const stored = otpStore.get(email)
   return stored === code
+}
+
+export function generateNonce(address: string) {
+  const nonce = Math.random().toString(36).slice(2, 10)
+  nonceStore.set(address.toLowerCase(), nonce)
+  setTimeout(() => nonceStore.delete(address.toLowerCase()), 5 * 60 * 1000)
+  return nonce
+}
+
+export function verifySiwe(address: string, signature: string) {
+  const nonce = nonceStore.get(address.toLowerCase())
+  if (!nonce) return false
+  const message = `Sign in with wallet: ${nonce}`
+  try {
+    const recovered = verifyMessage(message, signature)
+    nonceStore.delete(address.toLowerCase())
+    return recovered.toLowerCase() === address.toLowerCase()
+  } catch {
+    return false
+  }
 }
 
 function signAccessToken(payload: any) {
@@ -56,6 +78,31 @@ export async function findOrCreateUser(email: string, name?: string) {
       .values({ email, name, created_at: new Date().toISOString() })
       .run()
     user = { id: res.lastInsertRowid as number, email, name }
+    let buyerRole = db.select().from(roles).where(eq(roles.code, 'buyer')).get()
+    if (!buyerRole) {
+      const roleRes = db.insert(roles).values({ code: 'buyer' }).run()
+      buyerRole = { id: roleRes.lastInsertRowid as number, code: 'buyer' }
+    }
+    db.insert(userRoles).values({ user_id: user.id, role_id: buyerRole.id }).run()
+  }
+  const roleRows = db
+    .select({ code: roles.code })
+    .from(userRoles)
+    .leftJoin(roles, eq(userRoles.role_id, roles.id))
+    .where(eq(userRoles.user_id, user.id))
+    .all()
+  const roleCodes = roleRows.map((r) => r.code)
+  return { user, roles: roleCodes }
+}
+
+export async function findOrCreateUserByWallet(wallet: string) {
+  let user = db.select().from(users).where(eq(users.wallet, wallet)).get()
+  if (!user) {
+    const res = db
+      .insert(users)
+      .values({ wallet, created_at: new Date().toISOString() })
+      .run()
+    user = { id: res.lastInsertRowid as number, wallet }
     let buyerRole = db.select().from(roles).where(eq(roles.code, 'buyer')).get()
     if (!buyerRole) {
       const roleRes = db.insert(roles).values({ code: 'buyer' }).run()

--- a/nuxt-app/stores/useAuthStore.ts
+++ b/nuxt-app/stores/useAuthStore.ts
@@ -15,16 +15,16 @@ export const useAuthStore = defineStore('auth', {
       await $fetch('/api/auth/otp/request', { method: 'POST', body: { email } })
       this.email = email
     },
-    async verifyOtp(code: string, name?: string) {
-      const res = await $fetch<{ access: string; refresh: string }>('/api/auth/otp/verify', {
-        method: 'POST',
-        body: { email: this.email, code, name },
-      })
-      this.token = res.access
-      if (process.client) {
-        localStorage.setItem('token', res.access)
-      }
-    },
+      async verifyOtp(code: string, name?: string) {
+        const res = await $fetch<{ access: string }>('/api/auth/otp/verify', {
+          method: 'POST',
+          body: { email: this.email, code, name },
+        })
+        this.token = res.access
+        if (process.client) {
+          localStorage.setItem('token', res.access)
+        }
+      },
     async logout() {
       await $fetch('/api/auth/logout', { method: 'POST' })
       this.token = null


### PR DESCRIPTION
## Summary
- add wallet-based SIWE login endpoints and refresh-token cookie handling
- enforce role checks on risk, pricing, deals, claim, and tracker APIs
- annotate insurer, guarantor, deal-tracker, and risk-analysis pages with RBAC metadata

## Testing
- `npm run lint`
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_689abc996430832ea5f0cbc2d336001f