### PR TITLE
feat: upgrade node to 22 and add prom client

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --production

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,9 @@
   "name": "backend",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "h3": "^1.6.6",
     "node-fetch": "^3.3.2"

--- a/hardhat/Dockerfile
+++ b/hardhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/hardhat/package.json
+++ b/hardhat/package.json
@@ -1,6 +1,9 @@
 {
   "name": "hardhat",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "hardhat": "^2.22.0"

--- a/nuxt-app/Dockerfile
+++ b/nuxt-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:22
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -2,6 +2,9 @@
   "name": "nuxt-app",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",
@@ -23,6 +26,7 @@
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",
     "nuxt": "^4.0.1",
+    "prom-client": "^15.1.0",
     "vue": "^3.5.18",
     "vue-router": "^4.5.1",
     "winston": "^3.17.0",


### PR DESCRIPTION
## Summary
- upgrade Node base images and engines to v22
- add prom-client dependency for Nuxt metrics endpoint

## Testing
- `npm test` (fails: Could not locate better-sqlite3 bindings)
- `npm test` in backend (fails: Missing script "test")
- `npm test` in hardhat (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b2ad89bfc832e82a16f1144682657