### PR TITLE
chore: ignore node modules in docker build

### DIFF
--- a/nuxt-app/.dockerignore
+++ b/nuxt-app/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.nuxtrc
+.nuxt
+.DS_Store
+.git
+.gitignore
+.dockerignore
+Dockerfile
+cypress
+cypress.config.ts
+coverage
+*.log


### PR DESCRIPTION
## Summary
- prevent host node_modules from being copied into nuxt docker image
- keep container dependencies rebuilt for the proper architecture

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2dce540c832eaf694843a3d972ef