### PR TITLE
Allow kbai.dongwoo.dev in Vite dev server

### DIFF
--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -15,7 +15,8 @@ export default defineNuxtConfig({
   },
   vite: {
     server: {
-      host: true
+      host: true,
+      allowedHosts: ['kbai.dongwoo.dev'],
     }
   },
   nitro: {
@@ -27,6 +28,7 @@ export default defineNuxtConfig({
   vite: {
     server: {
       host: true,
+      allowedHosts: ['kbai.dongwoo.dev'],
     }
   }
 })


### PR DESCRIPTION
## Summary
- permit dev server requests from kbai.dongwoo.dev by adding it to Vite's allowed hosts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b83d8b0f4832eb05e0cdfb52de405