### PR TITLE
fix(auth): expose api base to client

### DIFF
--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -5,7 +5,9 @@ export default defineNuxtConfig({
   css: ['~/assets/tailwind.css'],
   modules: ['@vee-validate/nuxt'],
   runtimeConfig: {
-    apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
+    public: {
+      apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
+    }
   },
   postcss: {
     plugins: {

--- a/nuxt-app/pages/risk.vue
+++ b/nuxt-app/pages/risk.vue
@@ -40,7 +40,7 @@ const config = useRuntimeConfig();
 
 const onSubmit = handleSubmit(async (vals) => {
   const res = await $fetch<{ ml_score: number; sub_scores: Record<string, number> }>(
-    `${config.apiBase}/api/risk/score`,
+    `${config.public.apiBase}/api/risk/score`,
     { method: 'POST', body: { features: vals } }
   );
   risk.setScore(res.ml_score, res.sub_scores);

--- a/nuxt-app/stores/auth.ts
+++ b/nuxt-app/stores/auth.ts
@@ -1,4 +1,5 @@
-import { defineStore } from 'pinia';
+import { defineStore } from 'pinia'
+import { useRuntimeConfig } from '#imports'
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -12,7 +13,9 @@ export const useAuthStore = defineStore('auth', {
   }),
   actions: {
     async login(email: string, password: string) {
+      const config = useRuntimeConfig()
       await $fetch('/api/auth/password/login', {
+        baseURL: config.public.apiBase,
         method: 'POST',
         body: { email, password },
         credentials: 'include',
@@ -21,7 +24,9 @@ export const useAuthStore = defineStore('auth', {
       this.email = email
     },
     async register(email: string, password: string, name?: string) {
+      const config = useRuntimeConfig()
       await $fetch('/api/auth/password/register', {
+        baseURL: config.public.apiBase,
         method: 'POST',
         body: { email, password, name },
         credentials: 'include',
@@ -29,18 +34,29 @@ export const useAuthStore = defineStore('auth', {
       await this.login(email, password)
     },
     async requestOtp(email: string) {
-      await $fetch('/api/auth/otp/request', { method: 'POST', body: { email } })
+      const config = useRuntimeConfig()
+      await $fetch('/api/auth/otp/request', {
+        baseURL: config.public.apiBase,
+        method: 'POST',
+        body: { email },
+      })
       this.email = email
     },
     async verifyOtp(code: string, name?: string) {
+      const config = useRuntimeConfig()
       await $fetch('/api/auth/otp/verify', {
+        baseURL: config.public.apiBase,
         method: 'POST',
         body: { email: this.email, code, name },
       })
       this.isAuthenticated = true
     },
     async logout() {
-      await $fetch('/api/auth/logout', { method: 'POST' })
+      const config = useRuntimeConfig()
+      await $fetch('/api/auth/logout', {
+        baseURL: config.public.apiBase,
+        method: 'POST',
+      })
       this.isAuthenticated = false
       this.email = null
     },


### PR DESCRIPTION
## Summary
- expose API base URL via public runtime config so client-side code can reach backend
- update auth store and risk page to use `config.public.apiBase`

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b8724c160832e997704d037410001