### PR TITLE
Use local storage for auth in demo

### DIFF
--- a/nuxt-app/data/demo-users.ts
+++ b/nuxt-app/data/demo-users.ts
@@ -1,0 +1,9 @@
+export const demoUsers = {
+  buyer: { email: 'buyer@example.com', password: 'pass' },
+  seller: { email: 'seller@example.com', password: 'pass' },
+  guarantor: { email: 'guarantor@example.com', password: 'pass' },
+  insurer: { email: 'insurer@example.com', password: 'pass' },
+  admin: { email: 'admin@example.com', password: 'pass' }
+} as const
+
+export type DemoRole = keyof typeof demoUsers

--- a/nuxt-app/pages/deal-creation.vue
+++ b/nuxt-app/pages/deal-creation.vue
@@ -48,14 +48,17 @@
         <div>
           <label class="block text-sm font-medium mb-1">Seller</label>
           <input v-model="form.seller" type="text" class="input" />
+          <p class="help">Demo seller: {{ demoUsers.seller.email }}</p>
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Guarantor</label>
           <input v-model="form.guarantor" type="text" class="input" />
+          <p class="help">Demo guarantor: {{ demoUsers.guarantor.email }}</p>
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Insurer</label>
           <input v-model="form.insurer" type="text" class="input" />
+          <p class="help">Demo insurer: {{ demoUsers.insurer.email }}</p>
         </div>
         <button type="submit" class="btn btn-primary">Create</button>
       </form>
@@ -100,6 +103,7 @@
 
 <script setup lang="ts">
 import { reactive, ref, computed } from 'vue'
+import { demoUsers } from '~/data/demo-users'
 const router = useRouter()
 definePageMeta({ roles: ['buyer'] })
 
@@ -109,9 +113,9 @@ const form = reactive({
   incoterms: '',
   deposit: 0,
   milestones: [{ description: '', amount: 0 }] as { description: string; amount: number }[],
-  seller: '',
-  guarantor: '',
-  insurer: ''
+  seller: demoUsers.seller.email,
+  guarantor: demoUsers.guarantor.email,
+  insurer: demoUsers.insurer.email
 })
 
 const contractHash = ref('')

--- a/nuxt-app/pages/login.vue
+++ b/nuxt-app/pages/login.vue
@@ -9,6 +9,14 @@
       <p v-if="loginError" class="text-red-500 text-sm">{{ loginError }}</p>
       <NuxtLink to="/signup" class="text-sm text-center">Sign up</NuxtLink>
     </form>
+    <div class="mt-6">
+      <p class="font-medium text-sm mb-1">Demo accounts</p>
+      <ul class="list-disc pl-4 text-sm">
+        <li v-for="(info, role) in demoUsers" :key="role">
+          {{ role }}: {{ info.email }} / {{ info.password }}
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -16,6 +24,7 @@
 import { useAuthStore } from '~/stores/auth'
 import { useForm } from 'vee-validate'
 import * as yup from 'yup'
+import { demoUsers } from '~/data/demo-users'
 const auth = useAuthStore()
 const router = useRouter()
 const loginError = ref('')

--- a/nuxt-app/pages/risk-analysis.vue
+++ b/nuxt-app/pages/risk-analysis.vue
@@ -8,6 +8,7 @@
         <div>
           <label class="block text-sm font-medium mb-1">Counterparty</label>
           <input v-model="input.counterparty" type="text" class="input" />
+          <p class="help">Demo counterparty: {{ demoUsers.seller.email }}</p>
         </div>
         <div>
           <label class="block text-sm font-medium mb-1">Goods</label>
@@ -62,10 +63,11 @@
 <script setup lang="ts">
 import { reactive, ref, computed } from 'vue'
 import PremiumBreakdown from "~/components/PremiumBreakdown.vue";
+import { demoUsers } from '~/data/demo-users'
 
 definePageMeta({ roles: ['buyer', 'insurer'] })
 
-const input = reactive({ counterparty: '', goods: '', route: '' })
+const input = reactive({ counterparty: demoUsers.seller.email, goods: '', route: '' })
 const score = ref(0)
 const breakdown = ref<null | {
   base_rate: number

--- a/nuxt-app/plugins/demo-users.client.ts
+++ b/nuxt-app/plugins/demo-users.client.ts
@@ -1,0 +1,15 @@
+import { demoUsers } from '~/data/demo-users'
+
+export default defineNuxtPlugin(() => {
+  if (process.client) {
+    const existing = JSON.parse(localStorage.getItem('demo-users') || '{}')
+    if (!Object.keys(existing).length) {
+      const users: Record<string, { password: string; name: string }> = {}
+      for (const role in demoUsers) {
+        const { email, password } = (demoUsers as any)[role]
+        users[email] = { password, name: `Demo ${role}` }
+      }
+      localStorage.setItem('demo-users', JSON.stringify(users))
+    }
+  }
+})

--- a/nuxt-app/plugins/pinia.ts
+++ b/nuxt-app/plugins/pinia.ts
@@ -1,6 +1,10 @@
-import { createPinia } from 'pinia'
+import { createPinia, setActivePinia } from 'pinia'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const pinia = createPinia()
   nuxtApp.vueApp.use(pinia)
+  setActivePinia(pinia)
+  // expose to ensure stores work in middleware and other non-component contexts
+  // @ts-expect-error pinia is not typed on NuxtApp
+  nuxtApp.pinia = pinia
 })

--- a/nuxt-app/stores/auth.ts
+++ b/nuxt-app/stores/auth.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import { useRuntimeConfig } from '#imports'
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -13,50 +12,30 @@ export const useAuthStore = defineStore('auth', {
   }),
   actions: {
     async login(email: string, password: string) {
-      const config = useRuntimeConfig()
-      await $fetch('/api/auth/password/login', {
-        baseURL: config.public.apiBase,
-        method: 'POST',
-        body: { email, password },
-        credentials: 'include',
-      })
+      const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
+      if (!users[email] || users[email].password !== password) {
+        throw { statusMessage: 'Invalid email or password' }
+      }
       this.isAuthenticated = true
       this.email = email
     },
     async register(email: string, password: string, name?: string) {
-      const config = useRuntimeConfig()
-      await $fetch('/api/auth/password/register', {
-        baseURL: config.public.apiBase,
-        method: 'POST',
-        body: { email, password, name },
-        credentials: 'include',
-      })
-      await this.login(email, password)
+      const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
+      if (users[email]) {
+        throw { statusMessage: 'Email already in use' }
+      }
+      users[email] = { password, name }
+      localStorage.setItem('demo-users', JSON.stringify(users))
+      this.isAuthenticated = true
+      this.email = email
     },
     async requestOtp(email: string) {
-      const config = useRuntimeConfig()
-      await $fetch('/api/auth/otp/request', {
-        baseURL: config.public.apiBase,
-        method: 'POST',
-        body: { email },
-      })
       this.email = email
     },
     async verifyOtp(code: string, name?: string) {
-      const config = useRuntimeConfig()
-      await $fetch('/api/auth/otp/verify', {
-        baseURL: config.public.apiBase,
-        method: 'POST',
-        body: { email: this.email, code, name },
-      })
       this.isAuthenticated = true
     },
     async logout() {
-      const config = useRuntimeConfig()
-      await $fetch('/api/auth/logout', {
-        baseURL: config.public.apiBase,
-        method: 'POST',
-      })
       this.isAuthenticated = false
       this.email = null
     },


### PR DESCRIPTION
## Summary
- remove server calls for auth, rely on localStorage users for login and signup
- set active pinia instance so stores work in middleware and layouts
- seed demo user credentials and prefill role-based forms for quick testing

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689b918942ac832eac7998aa213bf2d9