### PR TITLE
Persist auth state for login and signup

### DIFF
--- a/nuxt-app/layouts/default.vue
+++ b/nuxt-app/layouts/default.vue
@@ -31,5 +31,7 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { onMounted } from 'vue'
 const auth = useAuthStore()
+onMounted(() => auth.load())
 </script>

--- a/nuxt-app/pages/login.vue
+++ b/nuxt-app/pages/login.vue
@@ -34,7 +34,7 @@ const onSubmit = handleSubmit(async (vals) => {
   loginError.value = ''
   try {
     await auth.login(vals.email, vals.password)
-    router.push('/')
+    await router.push('/')
   } catch (e: any) {
     loginError.value = e.statusMessage || 'Login failed. Please check your credentials.'
   }

--- a/nuxt-app/pages/signup.vue
+++ b/nuxt-app/pages/signup.vue
@@ -38,7 +38,7 @@ const onSubmit = handleSubmit(async (vals) => {
   signupError.value = ''
   try {
     await auth.register(vals.email, vals.password, vals.name)
-    router.push('/')
+    await router.push('/')
   } catch (e: any) {
     signupError.value = e.statusMessage || 'Registration failed. Email may be already in use.'
   }

--- a/nuxt-app/stores/auth.ts
+++ b/nuxt-app/stores/auth.ts
@@ -11,23 +11,38 @@ export const useAuthStore = defineStore('auth', {
     email: null,
   }),
   actions: {
-    async login(email: string, password: string) {
-      const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
-      if (!users[email] || users[email].password !== password) {
-        throw { statusMessage: 'Invalid email or password' }
+    load() {
+      if (process.client) {
+        const email = localStorage.getItem('demo-auth-email')
+        if (email) {
+          this.isAuthenticated = true
+          this.email = email
+        }
       }
-      this.isAuthenticated = true
-      this.email = email
+    },
+    async login(email: string, password: string) {
+      if (process.client) {
+        const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
+        if (!users[email] || users[email].password !== password) {
+          throw { statusMessage: 'Invalid email or password' }
+        }
+        this.isAuthenticated = true
+        this.email = email
+        localStorage.setItem('demo-auth-email', email)
+      }
     },
     async register(email: string, password: string, name?: string) {
-      const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
-      if (users[email]) {
-        throw { statusMessage: 'Email already in use' }
+      if (process.client) {
+        const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
+        if (users[email]) {
+          throw { statusMessage: 'Email already in use' }
+        }
+        users[email] = { password, name }
+        localStorage.setItem('demo-users', JSON.stringify(users))
+        this.isAuthenticated = true
+        this.email = email
+        localStorage.setItem('demo-auth-email', email)
       }
-      users[email] = { password, name }
-      localStorage.setItem('demo-users', JSON.stringify(users))
-      this.isAuthenticated = true
-      this.email = email
     },
     async requestOtp(email: string) {
       this.email = email
@@ -38,6 +53,9 @@ export const useAuthStore = defineStore('auth', {
     async logout() {
       this.isAuthenticated = false
       this.email = null
+      if (process.client) {
+        localStorage.removeItem('demo-auth-email')
+      }
     },
   },
 })


### PR DESCRIPTION
## Summary
- keep authentication state in localStorage and restore on app load
- redirect to home after successful login or signup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcaa1a334832eab596566f33b7d48