### PR TITLE
feat: add auth result modals

### DIFF
--- a/nuxt-app/components/StatusModal.vue
+++ b/nuxt-app/components/StatusModal.vue
@@ -1,0 +1,28 @@
+<template>
+  <transition name="fade">
+    <div v-if="modal.show" class="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div class="modal w-80 text-center">
+        <p :class="modal.type === 'error' ? 'text-rose-600' : 'text-brand-700'">
+          {{ modal.message }}
+        </p>
+        <button class="btn btn-primary mt-4" @click="modal.close()">확인</button>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { useModalStore } from '~/stores/modal'
+const modal = useModalStore()
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/nuxt-app/layouts/default.vue
+++ b/nuxt-app/layouts/default.vue
@@ -26,6 +26,7 @@
     <main class="flex-1">
       <slot />
     </main>
+    <StatusModal />
   </div>
 </template>
 

--- a/nuxt-app/pages/login.vue
+++ b/nuxt-app/pages/login.vue
@@ -6,7 +6,6 @@
       <input v-model="values.password" type="password" placeholder="Password" class="input" />
       <span class="text-red-500 text-sm" v-if="errors.password">{{ errors.password }}</span>
       <button type="submit" class="btn btn-primary">Login</button>
-      <p v-if="loginError" class="text-red-500 text-sm">{{ loginError }}</p>
       <NuxtLink to="/signup" class="text-sm text-center">Sign up</NuxtLink>
     </form>
   </div>
@@ -14,10 +13,11 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { useModalStore } from '~/stores/modal'
 import { useForm } from 'vee-validate'
 import * as yup from 'yup'
 const auth = useAuthStore()
-const loginError = ref('')
+const modal = useModalStore()
 
 const schema = yup.object({
   email: yup.string().email().required(),
@@ -30,12 +30,12 @@ const { handleSubmit, errors, values } = useForm<{ email: string; password: stri
 })
 
 const onSubmit = handleSubmit(async (vals) => {
-  loginError.value = ''
   try {
     await auth.login(vals.email, vals.password)
+    modal.open('로그인되었습니다.')
     await navigateTo('/')
   } catch (e: any) {
-    loginError.value = e.statusMessage || 'Login failed. Please check your credentials.'
+    modal.open(e.statusMessage || '로그인에 실패했습니다.', 'error')
   }
 })
 </script>

--- a/nuxt-app/pages/signup.vue
+++ b/nuxt-app/pages/signup.vue
@@ -9,7 +9,6 @@
       <span class="text-xs text-slate-500">Password must be at least 8 characters.</span>
       <span class="text-red-500 text-sm" v-if="errors.password">{{ errors.password }}</span>
       <button type="submit" class="btn btn-primary">Sign Up</button>
-      <p v-if="signupError" class="text-red-500 text-sm">{{ signupError }}</p>
       <NuxtLink to="/login" class="text-sm text-center">Back to login</NuxtLink>
     </form>
   </div>
@@ -17,10 +16,11 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { useModalStore } from '~/stores/modal'
 import { useForm } from 'vee-validate'
 import * as yup from 'yup'
 const auth = useAuthStore()
-const signupError = ref('')
+const modal = useModalStore()
 
 const schema = yup.object({
   email: yup.string().email().required(),
@@ -34,12 +34,12 @@ const { handleSubmit, errors, values } = useForm<{ email: string; name: string; 
 })
 
 const onSubmit = handleSubmit(async (vals) => {
-  signupError.value = ''
   try {
     await auth.register(vals.email, vals.password, vals.name)
+    modal.open('회원가입이 완료되었습니다.')
     await navigateTo('/')
   } catch (e: any) {
-    signupError.value = e.statusMessage || 'Registration failed. Email may be already in use.'
+    modal.open(e.statusMessage || '회원가입에 실패했습니다.', 'error')
   }
 })
 </script>

--- a/nuxt-app/stores/modal.ts
+++ b/nuxt-app/stores/modal.ts
@@ -1,0 +1,28 @@
+import { defineStore } from 'pinia'
+
+type ModalType = 'success' | 'error'
+
+type ModalState = {
+  show: boolean
+  message: string
+  type: ModalType
+}
+
+export const useModalStore = defineStore('modal', {
+  state: (): ModalState => ({
+    show: false,
+    message: '',
+    type: 'success',
+  }),
+  actions: {
+    open(message: string, type: ModalType = 'success') {
+      this.message = message
+      this.type = type
+      this.show = true
+    },
+    close() {
+      this.show = false
+      this.message = ''
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add Pinia modal store and global StatusModal component
- show success or error modals after login and signup and redirect to home
- include modal component in default layout and update auth pages to use it

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c09a2ae48832ea7c074d4686dbca1