### PR TITLE
feat: auto admin login and default demo users

### DIFF
--- a/nuxt-app/pages/deal-creation.vue
+++ b/nuxt-app/pages/deal-creation.vue
@@ -109,9 +109,9 @@ const form = reactive({
   incoterms: '',
   deposit: 0,
   milestones: [{ description: '', amount: 0 }] as { description: string; amount: number }[],
-  seller: '',
-  guarantor: '',
-  insurer: ''
+  seller: 'seller@example.com',
+  guarantor: 'guarantor@example.com',
+  insurer: 'insurer@example.com'
 })
 
 const contractHash = ref('')

--- a/nuxt-app/stores/auth.ts
+++ b/nuxt-app/stores/auth.ts
@@ -7,25 +7,22 @@ type AuthState = {
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
-    isAuthenticated: false,
-    email: null,
+    isAuthenticated: true,
+    email: 'admin@example.com',
   }),
   actions: {
     load() {
       if (process.client) {
         const users = JSON.parse(localStorage.getItem('demo-users') || '{}')
-        if (Object.keys(users).length === 0) {
-          localStorage.setItem('demo-users', JSON.stringify({
-            'buyer@example.com': { password: '1234567890', name: 'Buyer' },
-            'seller@example.com': { password: '1234567890', name: 'Seller' },
-            'insurer@example.com': { password: '1234567890', name: 'Insurer' },
-          }))
-        }
-        const email = localStorage.getItem('demo-auth-email')
-        if (email) {
-          this.isAuthenticated = true
-          this.email = email
-        }
+        users['admin@example.com'] = { password: '1234567890', name: 'Admin' }
+        users['buyer@example.com'] = { password: '1234567890', name: 'Buyer' }
+        users['seller@example.com'] = { password: '1234567890', name: 'Seller' }
+        users['guarantor@example.com'] = { password: '1234567890', name: 'Guarantor' }
+        users['insurer@example.com'] = { password: '1234567890', name: 'Insurer' }
+        localStorage.setItem('demo-users', JSON.stringify(users))
+        this.isAuthenticated = true
+        this.email = 'admin@example.com'
+        localStorage.setItem('demo-auth-email', 'admin@example.com')
       }
     },
     async login(email: string, password: string) {


### PR DESCRIPTION
## Summary
- default auth store to always sign in as admin
- prefill deal creation role fields with demo emails

## Testing
- `npm test` *(fails: The module 'better-sqlite3' was compiled against a different Node.js version)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c5cd2f06c832e963eebb265c8082a