### PR TITLE
Integrate axios/auth-next for persistent auth

### DIFF
--- a/nuxt-app/middleware/guest.ts
+++ b/nuxt-app/middleware/guest.ts
@@ -1,0 +1,6 @@
+export default defineNuxtRouteMiddleware(() => {
+  const auth = useAuth()
+  if (auth.loggedIn) {
+    return navigateTo('/')
+  }
+})

--- a/nuxt-app/middleware/route-guard.global.ts
+++ b/nuxt-app/middleware/route-guard.global.ts
@@ -1,14 +1,12 @@
-import { useStore } from 'vuex'
-
 export default defineNuxtRouteMiddleware((to) => {
   const required = (to.meta.roles as string[]) || []
   if (!required.length) return
-  const store = useStore()
-  const { isAuthenticated, role } = store.state.auth
-  if (!isAuthenticated) {
+  const auth = useAuth()
+  if (!auth.loggedIn) {
     return navigateTo('/login')
   }
-  if (role && !required.includes(role)) {
+  const roles: string[] = (auth.user as any)?.roles || []
+  if (required.length && !required.some((r) => roles.includes(r))) {
     return navigateTo('/')
   }
 })

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -3,22 +3,43 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   css: ['~/assets/tailwind.css'],
-  modules: ['@vee-validate/nuxt'],
+  modules: ['@nuxtjs/axios', '@nuxtjs/auth-next', '@vee-validate/nuxt'],
   runtimeConfig: {
     public: {
       apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
     }
   },
+  axios: {
+    baseURL: process.env.API_BASE_URL || 'http://localhost:3001',
+    credentials: true
+  },
+  auth: {
+    redirect: {
+      login: '/login',
+      logout: '/login',
+      home: '/'
+    },
+    strategies: {
+      local: {
+        token: {
+          required: false,
+          type: false
+        },
+        endpoints: {
+          login: { url: '/api/auth/password/login', method: 'post' },
+          logout: { url: '/api/auth/logout', method: 'post' },
+          user: { url: '/api/auth/user', method: 'get' }
+        }
+      }
+    }
+  },
+  router: {
+    middleware: ['auth']
+  },
   postcss: {
     plugins: {
       tailwindcss: {},
       autoprefixer: {}
-    }
-  },
-  vite: {
-    server: {
-      host: true,
-      allowedHosts: ['kbai.dongwoo.dev'],
     }
   },
   nitro: {
@@ -30,7 +51,7 @@ export default defineNuxtConfig({
   vite: {
     server: {
       host: true,
-      allowedHosts: ['kbai.dongwoo.dev'],
+      allowedHosts: ['kbai.dongwoo.dev']
     }
   }
 })

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -30,7 +30,9 @@
     "vue-router": "^4.5.1",
     "vuex": "^4.1.0",
     "winston": "^3.17.0",
-    "zod": "^3.25.0"
+    "zod": "^3.25.0",
+    "@nuxtjs/axios": "^5.13.6",
+    "@nuxtjs/auth-next": "^5.0.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",

--- a/nuxt-app/pages/login.vue
+++ b/nuxt-app/pages/login.vue
@@ -15,8 +15,8 @@
 <script setup lang="ts">
 import { useForm } from 'vee-validate'
 import * as yup from 'yup'
-import { useStore } from 'vuex'
-const store = useStore()
+
+const auth = useAuth()
 const loginError = ref('')
 
 const schema = yup.object({
@@ -32,10 +32,12 @@ const { handleSubmit, errors, values } = useForm<{ email: string; password: stri
 const onSubmit = handleSubmit(async (vals) => {
   loginError.value = ''
   try {
-    await store.dispatch('auth/login', { email: vals.email, password: vals.password })
+    await auth.loginWith('local', { data: { email: vals.email, password: vals.password } })
     await navigateTo('/')
   } catch (e: any) {
-    loginError.value = e.statusMessage || 'Login failed. Please check your credentials.'
+    loginError.value = e?.response?.data?.statusMessage || 'Login failed. Please check your credentials.'
   }
 })
+
+definePageMeta({ middleware: ['guest'], auth: false })
 </script>

--- a/nuxt-app/pages/signup.vue
+++ b/nuxt-app/pages/signup.vue
@@ -18,8 +18,9 @@
 <script setup lang="ts">
 import { useForm } from 'vee-validate'
 import * as yup from 'yup'
-import { useStore } from 'vuex'
-const store = useStore()
+
+const { $axios } = useNuxtApp()
+const auth = useAuth()
 const signupError = ref('')
 
 const schema = yup.object({
@@ -36,14 +37,17 @@ const { handleSubmit, errors, values } = useForm<{ email: string; name: string; 
 const onSubmit = handleSubmit(async (vals) => {
   signupError.value = ''
   try {
-    await store.dispatch('auth/register', {
+    await $axios.$post('/api/auth/password/register', {
       email: vals.email,
       password: vals.password,
       name: vals.name,
     })
+    await auth.loginWith('local', { data: { email: vals.email, password: vals.password } })
     await navigateTo('/')
   } catch (e: any) {
-    signupError.value = e.statusMessage || 'Registration failed. Email may be already in use.'
+    signupError.value = e?.response?.data?.statusMessage || 'Registration failed. Email may be already in use.'
   }
 })
+
+definePageMeta({ middleware: ['guest'], auth: false })
 </script>

--- a/nuxt-app/server/api/auth/user.get.ts
+++ b/nuxt-app/server/api/auth/user.get.ts
@@ -1,0 +1,12 @@
+import { createError } from 'h3'
+import { authGuard, getUserWithRoles } from '../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  await authGuard(event)
+  const id = event.context.user?.id
+  const data = getUserWithRoles(id)
+  if (!data) {
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+  return { id: data.user.id, email: data.user.email, roles: data.roles }
+})


### PR DESCRIPTION
## Summary
- configure axios and auth-next for cookie-based auth with global `auth` middleware
- add user endpoint and guest middleware for sign up/login flow
- refactor login and signup pages to use `$auth`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c73af1154832e98ab5d610db9f6b7