### PR TITLE
Replace external auth module with composable

### DIFF
--- a/nuxt-app/composables/useAuth.ts
+++ b/nuxt-app/composables/useAuth.ts
@@ -1,0 +1,32 @@
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+
+export const useAuth = () => {
+  const store = useStore()
+
+  const loggedIn = computed(() => store.state.auth.isAuthenticated)
+  const user = computed(() => {
+    if (!store.state.auth.isAuthenticated) {
+      return null
+    }
+    return {
+      email: store.state.auth.email as string,
+      roles: store.state.auth.role ? [store.state.auth.role] : []
+    }
+  })
+
+  const loginWith = async (_strategy: string, { data }: { data: { email: string; password: string } }) => {
+    await store.dispatch('auth/login', data)
+  }
+
+  const logout = async () => {
+    await store.dispatch('auth/logout')
+  }
+
+  return {
+    loggedIn,
+    user,
+    loginWith,
+    logout
+  }
+}

--- a/nuxt-app/middleware/guest.ts
+++ b/nuxt-app/middleware/guest.ts
@@ -1,6 +1,6 @@
 export default defineNuxtRouteMiddleware(() => {
   const auth = useAuth()
-  if (auth.loggedIn) {
+  if (auth.loggedIn.value) {
     return navigateTo('/')
   }
 })

--- a/nuxt-app/middleware/route-guard.global.ts
+++ b/nuxt-app/middleware/route-guard.global.ts
@@ -2,10 +2,10 @@ export default defineNuxtRouteMiddleware((to) => {
   const required = (to.meta.roles as string[]) || []
   if (!required.length) return
   const auth = useAuth()
-  if (!auth.loggedIn) {
+  if (!auth.loggedIn.value) {
     return navigateTo('/login')
   }
-  const roles: string[] = (auth.user as any)?.roles || []
+  const roles = auth.user.value?.roles || []
   if (required.length && !required.some((r) => roles.includes(r))) {
     return navigateTo('/')
   }

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   css: ['~/assets/tailwind.css'],
-  modules: ['@nuxtjs/axios', '@nuxtjs/auth-next', '@vee-validate/nuxt'],
+  modules: ['@nuxtjs/axios', '@vee-validate/nuxt'],
   runtimeConfig: {
     public: {
       apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
@@ -12,29 +12,6 @@ export default defineNuxtConfig({
   axios: {
     baseURL: process.env.API_BASE_URL || 'http://localhost:3001',
     credentials: true
-  },
-  auth: {
-    redirect: {
-      login: '/login',
-      logout: '/login',
-      home: '/'
-    },
-    strategies: {
-      local: {
-        token: {
-          required: false,
-          type: false
-        },
-        endpoints: {
-          login: { url: '/api/auth/password/login', method: 'post' },
-          logout: { url: '/api/auth/logout', method: 'post' },
-          user: { url: '/api/auth/user', method: 'get' }
-        }
-      }
-    }
-  },
-  router: {
-    middleware: ['auth']
   },
   postcss: {
     plugins: {

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -31,8 +31,7 @@
     "vuex": "^4.1.0",
     "winston": "^3.17.0",
     "zod": "^3.25.0",
-    "@nuxtjs/axios": "^5.13.6",
-    "@nuxtjs/auth-next": "^5.0.0"
+    "@nuxtjs/axios": "^5.13.6"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",


### PR DESCRIPTION
## Summary
- Drop @nuxtjs/auth-next module and config causing install errors
- Introduce local `useAuth` composable powered by Vuex
- Fix route middleware to read reactive auth state correctly

## Testing
- `npm install` (fails: 403 Forbidden fetching @parcel/watcher-wasm)
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_689c76380370832e9bf18262e08e8e89