### PR TITLE
refactor: switch to axios plugin and update build

### DIFF
--- a/nuxt-app/Dockerfile
+++ b/nuxt-app/Dockerfile
@@ -1,7 +1,33 @@
-FROM node:22
+# Stage 1: Build Stage
+FROM node:22-bullseye AS build
 WORKDIR /app
+
+# Install build tools for native addons
+RUN apt-get update && apt-get install -y python3 build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies with root permissions for scripts
 COPY package*.json ./
-RUN npm install
+RUN npm ci --unsafe-perm
+
+# Copy source and build application
 COPY . .
+RUN npm run build
+
+# Remove dev dependencies for production
+RUN npm prune --production
+
+# Stage 2: Runtime Stage
+FROM node:22-bullseye-slim AS runtime
+WORKDIR /app
+
+# Copy built output and production dependencies
+COPY --from=build /app/.output ./.output
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+
+ENV NODE_ENV=production
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+
+# Start Nuxt application
+CMD ["node", ".output/server/index.mjs"]

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -4,15 +4,11 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   css: ['~/assets/tailwind.css'],
-  modules: ['@nuxtjs/axios', '@vee-validate/nuxt'],
+  modules: ['@vee-validate/nuxt'],
   runtimeConfig: {
     public: {
       apiBase: process.env.API_BASE_URL || 'http://localhost:3001'
     }
-  },
-  axios: {
-    baseURL: process.env.API_BASE_URL || 'http://localhost:3001',
-    credentials: true
   },
   postcss: {
     plugins: {

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -31,7 +31,7 @@
     "vuex": "^4.1.0",
     "winston": "^3.17.0",
     "zod": "^3.25.0",
-    "@nuxtjs/axios": "^5.13.6"
+    "axios": "^1.4.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
@@ -48,5 +48,9 @@
     "vee-validate": "^4.12.6",
     "vitest": "^1.6.0",
     "yup": "^1.4.0"
+  },
+  "overrides": {
+    "glob": "^9.2.0",
+    "lodash.isequal": "npm:fast-deep-equal@^3.1.3"
   }
 }

--- a/nuxt-app/plugins/axios.ts
+++ b/nuxt-app/plugins/axios.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+  const apiClient = axios.create({ baseURL: config.public.apiBase })
+  return {
+    provide: {
+      axios: apiClient
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- replace deprecated @nuxtjs/axios module with a custom axios plugin
- enforce modern glob and fast-deep-equal via package overrides
- convert Dockerfile to multi-stage build with native build deps for Node 22

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8c60a674832e8ed97a802fad3568