### PR TITLE
chore: harden hardhat build

### DIFF
--- a/hardhat/Dockerfile
+++ b/hardhat/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:22
+FROM node:22-bullseye
 WORKDIR /app
+
 COPY package*.json ./
-RUN npm ci
+# Use lockfile when available, fallback to install if missing
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
 COPY . .
 RUN npx hardhat compile
+
 CMD ["npx","hardhat","node"]


### PR DESCRIPTION
## Summary
- make Hardhat Docker build resilient by using Debian-based image and falling back to npm install when lockfile is missing

## Testing
- `npx hardhat compile` *(fails: Couldn't download compiler version list)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8f71db04832e9012a5f734683ab8