### PR TITLE
Ensure training data directory exists before model training

### DIFF
--- a/ml-service/train_model.py
+++ b/ml-service/train_model.py
@@ -75,6 +75,10 @@ def train() -> Path:
     # Ensure some training data exists.  If the demo dataset is missing we
     # synthesise it so that the service can operate in a self-contained manner.
     if not DATA_PATH.exists():
+        # Create the directory structure expected for the training data. Without
+        # this ``to_csv`` would fail with ``OSError`` when the parent directory
+        # is missing.
+        DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
         generate_dummy_data(out_path=str(DATA_PATH))
 
     # Prefer real training if possible; otherwise fall back to a lightweight


### PR DESCRIPTION
## Summary
- Create required data directory before generating dummy data so training doesn't fail in Docker build

## Testing
- `python generate_dummy_data.py && python train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf754ae14832e8cc3f9b80d0eddbe